### PR TITLE
Add `license_url`

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ About cudatoolkit
 
 Home: https://developer.nvidia.com/cuda-toolkit
 
-Package license: NVIDIA End User License Agreement
+Package license: [NVIDIA End User License Agreement](https://docs.nvidia.com/cuda/eula/index.html)
 
 Feedstock license: [BSD-3-Clause](https://github.com/conda-forge/cudatoolkit-feedstock/blob/master/LICENSE.txt)
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -68,8 +68,8 @@ about:
   # A LicenceRef cannot be used in this case, see:
   # https://github.com/conda-forge/staged-recipes/pull/12882#discussion_r504086944
   license: NVIDIA End User License Agreement
-  # EULA available at https://docs.nvidia.com/cuda/eula/index.html
   license_file: NVIDIA_EULA
+  license_url: https://docs.nvidia.com/cuda/eula/index.html
   description: |
     CUDA is a parallel computing platform and programming model developed by NVIDIA for general computing on graphical processing units (GPUs). With CUDA, developers can dramatically speed up computing applications by harnessing the power of GPUs.
 


### PR DESCRIPTION
Includes the `license_url` field linking to the EULA in the recipe. Should be picked up by Anaconda.org as well.

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

Partially addresses issue ( https://github.com/conda-forge/cudatoolkit-feedstock/issues/2 ).

<!--
Please add any other relevant info below:
-->
