### PR TITLE
BUG: Add missing libnppicom for CUDA < 11

### DIFF
--- a/recipe/build.py
+++ b/recipe/build.py
@@ -103,6 +103,8 @@ class Extractor(object):
             self.cuda_libraries.append("cublasLt")
         if self.major_minor >= (10, 2):
             self.cuda_libraries.append("nvjpeg")
+        if self.major_minor < (11, 0):
+            self.cuda_libraries.append("nppicom")
         if self.major_minor >= (11, 0):
             self.cuda_libraries.append("cusolverMg")
         self.cuda_static_libraries = ["cudadevrt"]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -27,6 +27,8 @@
 #       https://developer.download.nvidia.com/compute/cuda/10.0/Prod/docs/sidebar/md5sum.txt
 #   For 9.2.148, the URL is:
 #       http://developer.download.nvidia.com/compute/cuda/9.2/Prod2/docs/sidebar/md5sum.txt
+# sysroot_version: The version of sysroot_linux-64 that will be used. Currently only used
+#   on linux64. If this key is not present, then no sysroot requirement is used.
 
 {% set cudavars = {
   "9.2": {
@@ -129,6 +131,7 @@
       "ppc64le": ".run",
       "win": ".exe",
     },
+    "sysroot_version": "2.17",
   },
 }
 %}
@@ -168,7 +171,7 @@ source:
     md5: {{ cudavars[major_minor]["checksums"]["win"] }}  # [win]
 
 build:
-  number: 0
+  number: 1
   script_env:
     - NVTOOLSEXT_INSTALL_PATH
     - DEBUG_INSTALLER_PATH
@@ -202,7 +205,9 @@ requirements:
     # for run_exports
     - {{ compiler('c') }}
     - {{ compiler('cxx') }}
-    - sysroot_linux-64 2.17  # [linux64]
+{% if "sysroot_version" in cudavars[major_minor] %}
+    - sysroot_linux-64 {{ cudavars[major_minor]["sysroot_version"] }}  # [linux64]
+{% endif %}
   run_constrained:
     - __cuda >={{ major_minor }}
 


### PR DESCRIPTION
libnppicom is a JPEG compression library for CUDA<11; it was superseded by libnvjpeg in 10.2.

Addresses [this comment](https://github.com/conda-forge/cudatoolkit-feedstock/issues/15#issuecomment-718007779).

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
