### PR TITLE
BUG: Add missing libnppicom for CUDA 9.2

### DIFF
--- a/recipe/build.py
+++ b/recipe/build.py
@@ -103,6 +103,8 @@ class Extractor(object):
             self.cuda_libraries.append("cublasLt")
         if self.major_minor >= (10, 2):
             self.cuda_libraries.append("nvjpeg")
+        if self.major_minor < (11, 0):
+            self.cuda_libraries.append("nppicom")
         if self.major_minor >= (11, 0):
             self.cuda_libraries.append("cusolverMg")
         self.cuda_static_libraries = ["cudadevrt"]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -171,7 +171,7 @@ source:
     md5: {{ cudavars[major_minor]["checksums"]["win"] }}  # [win]
 
 build:
-  number: 1
+  number: 2
   script_env:
     - NVTOOLSEXT_INSTALL_PATH
     - DEBUG_INSTALLER_PATH


### PR DESCRIPTION
libnppicom is a JPEG compression library for CUDA<11; it was superseded by libnvjpeg in 10.2.

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
