### PR TITLE
ENH Add CUDA 11.1.1 support

### DIFF
--- a/.azure-pipelines/azure-pipelines-win.yml
+++ b/.azure-pipelines/azure-pipelines-win.yml
@@ -17,8 +17,8 @@ jobs:
 
   steps:
     - script: |
-        choco install cuda --version=11.0.3 -fdv -y --debug
-      displayName: "Install Chocolatey Package: cuda --version=11.0.3"
+        choco install cuda --version=11.1.1 -fdv -y --debug
+      displayName: "Install Chocolatey Package: cuda --version=11.1.1"
 
     - script: |
         choco install vcpython27 -fdv -y --debug

--- a/.ci_support/linux_ppc64le_.yaml
+++ b/.ci_support/linux_ppc64le_.yaml
@@ -1,0 +1,21 @@
+c_compiler:
+- gcc
+c_compiler_version:
+- '8'
+cdt_name:
+- cos7
+channel_sources:
+- conda-forge,defaults
+channel_targets:
+- conda-forge test
+cxx_compiler:
+- gxx
+cxx_compiler_version:
+- '8'
+docker_image:
+- condaforge/linux-anvil-ppc64le
+target_platform:
+- linux-ppc64le
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,20 @@
+# This file was generated automatically from conda-smithy. To update this configuration,
+# update the conda-forge.yml and/or the recipe/meta.yaml.
+
+language: generic
+
+
+
+matrix:
+  include:
+    - env: CONFIG=linux_ppc64le_ UPLOAD_PACKAGES=True PLATFORM=linux-ppc64le DOCKER_IMAGE=condaforge/linux-anvil-ppc64le
+      os: linux
+      arch: ppc64le
+
+script:
+  - export CI=travis
+  - export GIT_BRANCH="$TRAVIS_BRANCH"
+  - export FEEDSTOCK_NAME=$(basename ${TRAVIS_REPO_SLUG})
+
+
+  - if [[ ${PLATFORM} =~ .*linux.* ]]; then ./.scripts/run_docker_build.sh; fi

--- a/README.md
+++ b/README.md
@@ -25,7 +25,14 @@ Current build status
 ====================
 
 
-<table>
+<table><tr>
+    <td>Travis</td>
+    <td>
+      <a href="https://travis-ci.com/conda-forge/cudatoolkit-feedstock">
+        <img alt="macOS" src="https://img.shields.io/travis/com/conda-forge/cudatoolkit-feedstock/master.svg?label=macOS">
+      </a>
+    </td>
+  </tr>
     
   <tr>
     <td>Azure</td>
@@ -43,6 +50,13 @@ Current build status
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=10936&branchName=master">
                   <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/cudatoolkit-feedstock?branchName=master&jobName=linux&configuration=linux_64_" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>linux_ppc64le</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=10936&branchName=master">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/cudatoolkit-feedstock?branchName=master&jobName=linux&configuration=linux_ppc64le_" alt="variant">
                 </a>
               </td>
             </tr><tr>

--- a/conda-forge.yml
+++ b/conda-forge.yml
@@ -1,4 +1,4 @@
 conda_forge_output_validation: true
 provider: {linux_aarch64: false, linux_ppc64le: default}
 choco:
-- cuda --version=11.0.3
+- cuda --version=11.1.1

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -133,6 +133,28 @@
     },
     "sysroot_version": "2.17",
   },
+  "11.1": {
+    "version": "11.1.1",
+    "version_patch": {
+      "linux64": "455.32.00",
+      "osx": "skip",
+      "ppc64le": "455.32.00",
+      "win": "456.81",
+    },
+    "subdomain": "developer.download",
+    "download_dir": "11.1.1",
+    "checksums": {
+      "linux64": "c24e2755e3868692051a38797ce01044",
+      "ppc64le": "d0b53036e8dcdc8dc22191feb913a3a0",
+      "win": "a89dfad35fc1adf02a848a9c06cfff15",
+    },
+    "blob_ext": {
+      "linux64": ".run",
+      "ppc64le": ".run",
+      "win": ".exe",
+    },
+    "sysroot_version": "2.17",
+  },
 }
 %}
 {% set version = cudavars[major_minor]["version"] %}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -3,7 +3,7 @@
 # Copyright (c) 2017, Continuum Analytics, Inc. All rights reserved.
 #
 # Distribution of the content approved by NVIDIA ( http://nvbugs/3052604 )
-{% set major_minor = "9.2" %}
+{% set major_minor = "11.1" %}
 
 # The following cudavars dictionary is a table of metadata for selecting various
 # paramaters based on the X.Y version number of cudatoolkit. The following is a description

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -193,7 +193,7 @@ source:
     md5: {{ cudavars[major_minor]["checksums"]["win"] }}  # [win]
 
 build:
-  number: 1
+  number: 0
   script_env:
     - NVTOOLSEXT_INSTALL_PATH
     - DEBUG_INSTALLER_PATH


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
This follows AnacondaRecipes/cudatoolkit-feedstock#13 which was for `11.1.0` but has not been reviewed yet

The idea is to get `11.1` out ASAP through `conda-forge` for those who need it, and Anaconda can copy this package into the `defaults` channel later

Given this is a different recipe approach from the PR above, I welcome feedback to know how to best contribute new versions in the future

cc @jakirkham @scopatz @raydouglass @kkraus14 
