### PR TITLE
Drop `cuinj64` and `accinj64` libraries

### DIFF
--- a/recipe/build.py
+++ b/recipe/build.py
@@ -204,7 +204,6 @@ class WindowsExtractor(Extractor):
 
     def __init__(self, plat, version, version_patch, runfile):
         super().__init__(plat, version, version_patch, runfile)
-        self.cuda_libraries.append("cuinj")
         self.embedded_blob = None
         self.symlinks = False
         if self.major_minor == (9, 2):
@@ -310,6 +309,7 @@ class LinuxExtractor(Extractor):
 
     def __init__(self, plat, version, version_patch, runfile):
         super().__init__(plat, version, version_patch, runfile)
+        self.embedded_blob = None
         self.symlinks = True
         # need globs to handle symlinks
         self.cuda_lib_fmt = "lib{0}.so*"
@@ -320,19 +320,6 @@ class LinuxExtractor(Extractor):
         self.libdir = "lib"
         self.cuda_lib_reldir = "lib64"
         self.machine = platform.machine()
-
-        if self.machine == "ppc64le":
-            # Power 8 Arch
-            cuda_libs = ["accinj64", "cuinj64"]
-            self.embedded_blob = None
-            if self.major_minor <= (10, 1):
-                self.cuda_lib_reldir = "targets/ppc64le-linux/lib"
-        else:
-            # x86-64 Arch
-            cuda_libs = ["accinj64", "cuinj64"]
-            self.embedded_blob = None
-        self.cuda_libraries.extend(cuda_libs)
-
         self.post_init()
 
     def copy(self, basepath):

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -171,7 +171,7 @@ source:
     md5: {{ cudavars[major_minor]["checksums"]["win"] }}  # [win]
 
 build:
-  number: 2
+  number: 3
   script_env:
     - NVTOOLSEXT_INSTALL_PATH
     - DEBUG_INSTALLER_PATH

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -217,6 +217,11 @@ test:
     - numba
     - python >=3.7
     - setuptools  # for pkg_resources
+  commands:
+    - test ! -f "${PREFIX}/lib/libaccinj64.so"         # [linux]
+    - test ! -f "${PREFIX}/lib/libcuinj64.so"          # [linux]
+    - if exist %LIBRARY_BIN%\\libaccinj64*.dll exit 1  # [win]
+    - if exist %LIBRARY_BIN%\\libcuinj64*.dll exit 1   # [win]
 
 about:
   home: https://developer.nvidia.com/cuda-toolkit


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

Fixes https://github.com/conda-forge/cudatoolkit-feedstock/issues/30

<!--
Please add any other relevant info below:
-->
