### PR TITLE
nvjpeg seems to be present in CUDA 10.0 and above

### DIFF
--- a/recipe/build.py
+++ b/recipe/build.py
@@ -101,7 +101,7 @@ class Extractor(object):
         ]
         if self.major_minor >= (10, 1):
             self.cuda_libraries.append("cublasLt")
-        if self.major_minor >= (10, 2):
+        if self.major_minor >= (10, 0):
             self.cuda_libraries.append("nvjpeg")
         if self.major_minor < (11, 0):
             self.cuda_libraries.append("nppicom")

--- a/recipe/build.py
+++ b/recipe/build.py
@@ -99,10 +99,10 @@ class Extractor(object):
             "nvrtc",
             "nvrtc-builtins",
         ]
+        if (getplatform() == "linux" and self.major_minor == (10, 0)) or (self.major_minor >= (10, 1)):
+            self.cuda_libraries.append("nvjpeg")
         if self.major_minor >= (10, 1):
             self.cuda_libraries.append("cublasLt")
-        if self.major_minor >= (10, 0):
-            self.cuda_libraries.append("nvjpeg")
         if self.major_minor < (11, 0):
             self.cuda_libraries.append("nppicom")
         if self.major_minor >= (11, 0):

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -171,7 +171,7 @@ source:
     md5: {{ cudavars[major_minor]["checksums"]["win"] }}  # [win]
 
 build:
-  number: 3
+  number: 4
   script_env:
     - NVTOOLSEXT_INSTALL_PATH
     - DEBUG_INSTALLER_PATH


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [X] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [X] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [X] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->

Closes #29. According to the attachments (see links below), `nvjpeg` should be present in CUDA 10.0 and above.

* [CUDA 10.0](https://docs.nvidia.com/cuda/archive/10.0/eula/index.html#attachment-a) -- linux only?
* [CUDA 10.1](https://docs.nvidia.com/cuda/archive/10.1/eula/index.html#attachment-a)
* [CUDA 10.2](https://docs.nvidia.com/cuda/archive/10.2/eula/index.html#attachment-a)
* [CUDA 11.0](https://docs.nvidia.com/cuda/archive/11.0/eula/index.html#attachment-a)