### PR TITLE
ENH Add SBSA aarch64 CTK pkgs for CUDA 11.X

### DIFF
--- a/.azure-pipelines/azure-pipelines-linux.yml
+++ b/.azure-pipelines/azure-pipelines-linux.yml
@@ -40,6 +40,22 @@ jobs:
         CONFIG: linux_64_major_minor_ver9.2
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
+      linux_aarch64_major_minor_ver11.0:
+        CONFIG: linux_aarch64_major_minor_ver11.0
+        UPLOAD_PACKAGES: 'True'
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-aarch64
+      linux_aarch64_major_minor_ver11.1:
+        CONFIG: linux_aarch64_major_minor_ver11.1
+        UPLOAD_PACKAGES: 'True'
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-aarch64
+      linux_aarch64_major_minor_ver11.2:
+        CONFIG: linux_aarch64_major_minor_ver11.2
+        UPLOAD_PACKAGES: 'True'
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-aarch64
+      linux_aarch64_major_minor_ver11.2.1:
+        CONFIG: linux_aarch64_major_minor_ver11.2.1
+        UPLOAD_PACKAGES: 'True'
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-aarch64
       linux_ppc64le_major_minor_ver10.2:
         CONFIG: linux_ppc64le_major_minor_ver10.2
         UPLOAD_PACKAGES: 'True'

--- a/.ci_support/linux_aarch64_major_minor_ver11.0.yaml
+++ b/.ci_support/linux_aarch64_major_minor_ver11.0.yaml
@@ -1,0 +1,27 @@
+BUILD:
+- aarch64-conda_cos7-linux-gnu
+c_compiler:
+- gcc
+c_compiler_version:
+- '9'
+cdt_arch:
+- aarch64
+cdt_name:
+- cos7
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+cxx_compiler:
+- gxx
+cxx_compiler_version:
+- '9'
+docker_image:
+- quay.io/condaforge/linux-anvil-aarch64
+major_minor_ver:
+- '11.0'
+target_platform:
+- linux-aarch64
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version

--- a/.ci_support/linux_aarch64_major_minor_ver11.1.yaml
+++ b/.ci_support/linux_aarch64_major_minor_ver11.1.yaml
@@ -1,0 +1,27 @@
+BUILD:
+- aarch64-conda_cos7-linux-gnu
+c_compiler:
+- gcc
+c_compiler_version:
+- '9'
+cdt_arch:
+- aarch64
+cdt_name:
+- cos7
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+cxx_compiler:
+- gxx
+cxx_compiler_version:
+- '9'
+docker_image:
+- quay.io/condaforge/linux-anvil-aarch64
+major_minor_ver:
+- '11.1'
+target_platform:
+- linux-aarch64
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version

--- a/.ci_support/linux_aarch64_major_minor_ver11.2.1.yaml
+++ b/.ci_support/linux_aarch64_major_minor_ver11.2.1.yaml
@@ -1,0 +1,27 @@
+BUILD:
+- aarch64-conda_cos7-linux-gnu
+c_compiler:
+- gcc
+c_compiler_version:
+- '9'
+cdt_arch:
+- aarch64
+cdt_name:
+- cos7
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+cxx_compiler:
+- gxx
+cxx_compiler_version:
+- '9'
+docker_image:
+- quay.io/condaforge/linux-anvil-aarch64
+major_minor_ver:
+- 11.2.1
+target_platform:
+- linux-aarch64
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version

--- a/.ci_support/linux_aarch64_major_minor_ver11.2.yaml
+++ b/.ci_support/linux_aarch64_major_minor_ver11.2.yaml
@@ -1,0 +1,27 @@
+BUILD:
+- aarch64-conda_cos7-linux-gnu
+c_compiler:
+- gcc
+c_compiler_version:
+- '9'
+cdt_arch:
+- aarch64
+cdt_name:
+- cos7
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+cxx_compiler:
+- gxx
+cxx_compiler_version:
+- '9'
+docker_image:
+- quay.io/condaforge/linux-anvil-aarch64
+major_minor_ver:
+- '11.2'
+target_platform:
+- linux-aarch64
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version

--- a/.scripts/build_steps.sh
+++ b/.scripts/build_steps.sh
@@ -6,8 +6,14 @@
 # benefit from the improvement.
 
 set -xeuo pipefail
-export PYTHONUNBUFFERED=1
 export FEEDSTOCK_ROOT="${FEEDSTOCK_ROOT:-/home/conda/feedstock_root}"
+source ${FEEDSTOCK_ROOT}/.scripts/logging_utils.sh
+
+
+endgroup "Start Docker"
+
+startgroup "Configuring conda"
+export PYTHONUNBUFFERED=1
 export RECIPE_ROOT="${RECIPE_ROOT:-/home/conda/recipe_root}"
 export CI_SUPPORT="${FEEDSTOCK_ROOT}/.ci_support"
 export CONFIG_FILE="${CI_SUPPORT}/${CONFIG}.yaml"
@@ -18,8 +24,9 @@ conda-build:
  root-dir: ${FEEDSTOCK_ROOT}/build_artifacts
 
 CONDARC
+BUILD_CMD=build
 
-conda install --yes --quiet "conda-forge-ci-setup=3" conda-build pip -c conda-forge
+conda install --yes --quiet "conda-forge-ci-setup=3" conda-build pip ${GET_BOA:-} -c conda-forge
 
 # set up the condarc
 setup_conda_rc "${FEEDSTOCK_ROOT}" "${RECIPE_ROOT}" "${CONFIG_FILE}"
@@ -37,24 +44,33 @@ source run_conda_forge_build_setup
 # make the build number clobber
 make_build_number "${FEEDSTOCK_ROOT}" "${RECIPE_ROOT}" "${CONFIG_FILE}"
 
+endgroup "Configuring conda"
 
 if [[ "${BUILD_WITH_CONDA_DEBUG:-0}" == 1 ]]; then
+    startgroup "Running conda debug"
     if [[ "x${BUILD_OUTPUT_ID:-}" != "x" ]]; then
         EXTRA_CB_OPTIONS="${EXTRA_CB_OPTIONS:-} --output-id ${BUILD_OUTPUT_ID}"
     fi
     conda debug "${RECIPE_ROOT}" -m "${CI_SUPPORT}/${CONFIG}.yaml" \
         ${EXTRA_CB_OPTIONS:-} \
         --clobber-file "${CI_SUPPORT}/clobber_${CONFIG}.yaml"
+    endgroup "Running conda debug"
     # Drop into an interactive shell
     /bin/bash
 else
-    conda build "${RECIPE_ROOT}" -m "${CI_SUPPORT}/${CONFIG}.yaml" \
+    startgroup "Running conda $BUILD_CMD"
+    conda $BUILD_CMD "${RECIPE_ROOT}" -m "${CI_SUPPORT}/${CONFIG}.yaml" \
         --suppress-variables ${EXTRA_CB_OPTIONS:-} \
         --clobber-file "${CI_SUPPORT}/clobber_${CONFIG}.yaml"
+    endgroup "Running conda build"
+    startgroup "Validating outputs"
     validate_recipe_outputs "${FEEDSTOCK_NAME}"
+    endgroup "Validating outputs"
 
     if [[ "${UPLOAD_PACKAGES}" != "False" ]]; then
+        startgroup "Uploading packages"
         upload_package --validate --feedstock-name="${FEEDSTOCK_NAME}"  "${FEEDSTOCK_ROOT}" "${RECIPE_ROOT}" "${CONFIG_FILE}"
+        endgroup "Uploading packages"
     fi
 fi
 

--- a/.scripts/logging_utils.sh
+++ b/.scripts/logging_utils.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+# Provide a unified interface for the different logging
+# utilities CI providers offer. If unavailable, provide
+# a compatible fallback (e.g. bare `echo xxxxxx`).
+
+function startgroup {
+    # Start a foldable group of log lines
+    # Pass a single argument, quoted
+    case ${CI:-} in
+        azure )
+            echo "##[group]$1";;
+        travis )
+            echo "$1"
+            echo -en 'travis_fold:start:'"${1// /}"'\\r';;
+        * )
+            echo "$1";;
+    esac
+}
+
+function endgroup {
+    # End a foldable group of log lines
+    # Pass a single argument, quoted
+    case ${CI:-} in
+        azure )
+            echo "##[endgroup]";;
+        travis )
+            echo -en 'travis_fold:end:'"${1// /}"'\\r';;
+    esac
+}

--- a/.scripts/run_docker_build.sh
+++ b/.scripts/run_docker_build.sh
@@ -5,6 +5,10 @@
 # changes to this script, consider a proposal to conda-smithy so that other feedstocks can also
 # benefit from the improvement.
 
+source .scripts/logging_utils.sh
+
+startgroup "Configure Docker"
+
 set -xeo pipefail
 
 THISDIR="$( cd "$( dirname "$0" )" >/dev/null && pwd )"
@@ -65,7 +69,9 @@ DOCKER_RUN_ARGS="${CONDA_FORGE_DOCKER_RUN_ARGS}"
 if [ -z "${CI}" ]; then
     DOCKER_RUN_ARGS="-it ${DOCKER_RUN_ARGS}"
 fi
+endgroup "Configure Docker"
 
+startgroup "Start Docker"
 export UPLOAD_PACKAGES="${UPLOAD_PACKAGES:-True}"
 docker run ${DOCKER_RUN_ARGS} \
            -v "${RECIPE_ROOT}":/home/conda/recipe_root:rw,z,delegated \

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,5 +1,5 @@
 BSD 3-clause license
-Copyright (c) 2015-2020, conda-forge contributors
+Copyright (c) 2015-2021, conda-forge contributors
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:

--- a/README.md
+++ b/README.md
@@ -95,6 +95,34 @@ Current build status
                 </a>
               </td>
             </tr><tr>
+              <td>linux_aarch64_major_minor_ver11.0</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=10936&branchName=master">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/cudatoolkit-feedstock?branchName=master&jobName=linux&configuration=linux_aarch64_major_minor_ver11.0" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>linux_aarch64_major_minor_ver11.1</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=10936&branchName=master">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/cudatoolkit-feedstock?branchName=master&jobName=linux&configuration=linux_aarch64_major_minor_ver11.1" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>linux_aarch64_major_minor_ver11.2</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=10936&branchName=master">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/cudatoolkit-feedstock?branchName=master&jobName=linux&configuration=linux_aarch64_major_minor_ver11.2" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>linux_aarch64_major_minor_ver11.2.1</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=10936&branchName=master">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/cudatoolkit-feedstock?branchName=master&jobName=linux&configuration=linux_aarch64_major_minor_ver11.2.1" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
               <td>linux_ppc64le_major_minor_ver10.2</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=10936&branchName=master">
@@ -277,9 +305,9 @@ build distinct package versions.
 
 In order to produce a uniquely identifiable distribution:
  * If the version of a package **is not** being increased, please add or increase
-   the [``build/number``](https://conda.io/docs/user-guide/tasks/build-packages/define-metadata.html#build-number-and-string).
+   the [``build/number``](https://docs.conda.io/projects/conda-build/en/latest/resources/define-metadata.html#build-number-and-string).
  * If the version of a package **is** being increased, please remember to return
-   the [``build/number``](https://conda.io/docs/user-guide/tasks/build-packages/define-metadata.html#build-number-and-string)
+   the [``build/number``](https://docs.conda.io/projects/conda-build/en/latest/resources/define-metadata.html#build-number-and-string)
    back to 0.
 
 Feedstock Maintainers

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Package license: [NVIDIA End User License Agreement](https://docs.nvidia.com/cud
 
 Feedstock license: [BSD-3-Clause](https://github.com/conda-forge/cudatoolkit-feedstock/blob/master/LICENSE.txt)
 
-Summary: CUDA Toolkit - Including CUDA runtime and headers
+Summary: CUDA Toolkit - Including CUDA runtime
 
 Development: https://developer.nvidia.com/cuda-downloads
 

--- a/conda-forge.yml
+++ b/conda-forge.yml
@@ -1,4 +1,4 @@
 conda_forge_output_validation: true
-provider: {linux_aarch64: false, linux_ppc64le: azure}
+provider: {linux_aarch64: azure, linux_ppc64le: azure}
 choco:
 - cuda --version=11.1.1

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -34,6 +34,7 @@
   "9.2": {
     "version": "9.2.148",
     "version_patch": {
+      "aarch64": "skip",
       "linux64": "396.37",
       "osx": "skip",
       "ppc64le": "skip",
@@ -53,6 +54,7 @@
   "10.0": {
     "version": "10.0.130",
     "version_patch": {
+      "aarch64": "skip",
       "linux64": "410.48",
       "osx": "skip",
       "ppc64le": "skip",
@@ -72,6 +74,7 @@
   "10.1": {
     "version": "10.1.243",
     "version_patch": {
+      "aarch64": "skip",
       "linux64": "418.87.00",
       "osx": "skip",
       "ppc64le": "skip",
@@ -93,6 +96,7 @@
   "10.2": {
     "version": "10.2.89",
     "version_patch": {
+      "aarch64": "skip",
       "linux64": "440.33.01",
       "osx": "skip",
       "ppc64le": "440.33.01",
@@ -114,6 +118,7 @@
   "11.0": {
     "version": "11.0.3",
     "version_patch": {
+      "aarch64": "450.51.06",
       "linux64": "450.51.06",
       "osx": "skip",
       "ppc64le": "450.51.06",
@@ -122,11 +127,13 @@
     "subdomain": "developer.download",
     "download_dir": "11.0.3",
     "checksums": {
+      "aarch64": "7f4e95eb69e2241dd278fc2002dfd66a",
       "linux64": "70af4cebe30549b9995fb9c57d538214",
       "ppc64le": "dabba7135b466d6726eade724d2eb598",
       "win": "80ae0fdbe04759123f3cab81f2aadabd",
     },
     "blob_ext": {
+      "aarch64": ".run",
       "linux64": ".run",
       "ppc64le": ".run",
       "win": ".exe",
@@ -136,6 +143,7 @@
   "11.1": {
     "version": "11.1.1",
     "version_patch": {
+      "aarch64": "455.32.00",
       "linux64": "455.32.00",
       "osx": "skip",
       "ppc64le": "455.32.00",
@@ -144,11 +152,13 @@
     "subdomain": "developer.download",
     "download_dir": "11.1.1",
     "checksums": {
+      "aarch64": "fc38718c96f1a382f2e5f56e5c081fd7",
       "linux64": "c24e2755e3868692051a38797ce01044",
       "ppc64le": "d0b53036e8dcdc8dc22191feb913a3a0",
       "win": "a89dfad35fc1adf02a848a9c06cfff15",
     },
     "blob_ext": {
+      "aarch64": ".run",
       "linux64": ".run",
       "ppc64le": ".run",
       "win": ".exe",
@@ -158,6 +168,7 @@
   "11.2": {
     "version": "11.2.0",
     "version_patch": {
+      "aarch64": "460.27.04",
       "linux64": "460.27.04",
       "osx": "skip",
       "ppc64le": "460.27.04",
@@ -166,11 +177,13 @@
     "subdomain": "developer.download",
     "download_dir": "11.2.0",
     "checksums": {
+      "aarch64": "ba4cdf47ef674cc425e8e264764af9da",
       "linux64": "04b39f63c3b97153631ca12ed230be51",
       "ppc64le": "d253e8971d4133426900b42632662d31",
       "win": "92f38c37ce9c6c11d27c10701b040256",
     },
     "blob_ext": {
+      "aarch64": ".run",
       "linux64": ".run",
       "ppc64le": ".run",
       "win": ".exe",
@@ -180,6 +193,7 @@
   "11.2.1": {
     "version": "11.2.1",
     "version_patch": {
+      "aarch64": "460.32.03",
       "linux64": "460.32.03",
       "osx": "skip",
       "ppc64le": "460.32.03",
@@ -188,11 +202,13 @@
     "subdomain": "developer.download",
     "download_dir": "11.2.1",
     "checksums": {
+      "aarch64": "fff82a14d4274b5173e0d6cb9f7f101c",
       "linux64": "5e33c4fdb409b299b85039e2a223c279",
       "ppc64le": "e4b2492a5476c994576d7c964ceaf59c",
       "win": "c34b541d8706b5aa0d8ba7313fff78e7",
     },
     "blob_ext": {
+      "aarch64": ".run",
       "linux64": ".run",
       "ppc64le": ".run",
       "win": ".exe",

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -322,7 +322,7 @@ about:
 
     License Agreements
     The packages are governed by the CUDA Toolkit End User License Agreement (EULA). By downloading and using the packages, you accept the terms and conditions of the CUDA EULA - https://docs.nvidia.com/cuda/eula/index.html
-  summary: 'CUDA Toolkit - Including CUDA runtime and headers'
+  summary: 'CUDA Toolkit - Including CUDA runtime'
   doc_url: https://docs.nvidia.com/cuda/
   dev_url: https://developer.nvidia.com/cuda-downloads
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -218,6 +218,7 @@
 }
 %}
 {% set version = cudavars[major_minor]["version"] %}
+{% set version_patch = cudavars[major_minor]["version_patch"]["aarch64"] %}  # [aarch64]
 {% set version_patch = cudavars[major_minor]["version_patch"]["linux64"] %}  # [linux64]
 {% set version_patch = cudavars[major_minor]["version_patch"]["osx"] %}  # [osx]
 {% set version_patch = cudavars[major_minor]["version_patch"]["ppc64le"] %}  # [ppc64le]
@@ -232,6 +233,7 @@
     {% set version_patch_underscore = "_" %}
 {% endif %}
 {% set runfile_pre = "cuda_" + version + version_patch_underscore + version_patch %}
+{% set runfile = runfile_pre + "_linux_sbsa" + cudavars[major_minor]["blob_ext"].get("aarch64", "NONE") %}  # [aarch64]
 {% set runfile = runfile_pre + "_linux" + cudavars[major_minor]["blob_ext"].get("linux64", "NONE") %}  # [linux64]
 {% set runfile = runfile_pre + "_mac" + cudavars[major_minor]["blob_ext"].get("osx", "NONE") %}  # [osx]
 {% set runfile = runfile_pre + "_linux_ppc64le" + cudavars[major_minor]["blob_ext"].get("ppc64le", "NONE") %}  # [ppc64le]
@@ -247,6 +249,7 @@ source:
   - path: ./build.py
   - fn: {{ runfile }}
     url: https://{{ subdomain }}.nvidia.com/compute/cuda/{{ download_dir }}/local_installers/{{ runfile }}
+    md5: {{ cudavars[major_minor]["checksums"]["aarch64"] }}  # [aarch64]
     md5: {{ cudavars[major_minor]["checksums"]["linux64"] }}  # [linux64]
     md5: {{ cudavars[major_minor]["checksums"]["osx"] }}  # [osx]
     md5: {{ cudavars[major_minor]["checksums"]["ppc64le"] }}  # [ppc64le]


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
Add `aarch64` support with the SBSA runfile for CUDA 11.X versions

**NOTE:** This does not support the Jetson/AGX platform. Those images use L4T which is **not** compatible with the SBSA installs. Currently Jetson/AGX only support CUDA 10.2 and SBSA only supports CUDA 11.X so there is no overlap at the moment. We're actively working with internal teams on how to best address this when AGX adopts CUDA 11.X support but that is still TBD. 

For Jetson/AGX builds that use conda it's recommended to use a selector and omit the CTK from recipes for now. This means users have to ensure they have the correct version of CUDA installed on their system and it doesn't allow for versioning but the currently JetPack for AGX/Jetson *only* supports CUDA 10.2