### PR TITLE
fix run constraint for cudatoolkit>=11.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -443,6 +443,7 @@
 }
 %}
 {% set version = cudavars[major_minor]["version"] %}
+{% set major_version = version.split('.')[0]|int %}
 {% set version_patch = cudavars[major_minor]["version_patch"]["aarch64"] %}  # [aarch64]
 {% set version_patch = cudavars[major_minor]["version_patch"]["linux64"] %}  # [linux64]
 {% set version_patch = cudavars[major_minor]["version_patch"]["osx"] %}  # [osx]
@@ -481,7 +482,7 @@ source:
     md5: {{ cudavars[major_minor]["checksums"]["win"] }}  # [win]
 
 build:
-  number: 9
+  number: 10
   script_env:
     - NVTOOLSEXT_INSTALL_PATH
     - DEBUG_INSTALLER_PATH
@@ -522,7 +523,11 @@ requirements:
     - sysroot_linux-aarch64 {{ cudavars[major_minor]["sysroot_version"] }}  # [aarch64]
 {% endif %}
   run_constrained:
+{% if major_version < 11 %}
     - __cuda >={{ major_minor }}
+{% else %}
+    - __cuda >={{ major_version }}
+{% endif %}
     - arm-variant * {{ arm_variant_type }}  # [aarch64]
 
 test:


### PR DESCRIPTION
Fixes #71

According to https://docs.nvidia.com/deploy/cuda-compatibility/, cudatoolkit 11.X should run on all systems with `__cuda 11.0-11.6`. Similar to https://github.com/conda-forge/nvcc-feedstock/pull/71/files, the run_constraint is fixed.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
