### PR TITLE
Require `cuda-version` match the `cudatoolkit` version

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -573,6 +573,8 @@ requirements:
     - sysroot_linux-64 {{ cudavars[major_minor]["sysroot_version"] }}       # [linux64]
     - sysroot_linux-aarch64 {{ cudavars[major_minor]["sysroot_version"] }}  # [aarch64]
 {% endif %}
+  run:
+    - cuda-version {{ major_minor }}
   run_constrained:
 {% if major_version < 11 %}
     - __cuda >={{ major_minor }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -533,7 +533,7 @@ source:
     md5: {{ cudavars[major_minor]["checksums"]["win"] }}  # [win]
 
 build:
-  number: 11
+  number: 12
   script_env:
     - NVTOOLSEXT_INSTALL_PATH
     - DEBUG_INSTALLER_PATH


### PR DESCRIPTION
Extends `cuda-version` usage to existing CUDA versions supported by `cudatoolkit`. This follows from the discussion in issue ( https://github.com/conda-forge/cuda-version-feedstock/issues/1 ) about how `cuda-version` will be used.

<hr>

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
