### PR TITLE
Remove outdated comment regarding LicenseRef

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -720,8 +720,6 @@ test:
 
 about:
   home: https://developer.nvidia.com/cuda-toolkit
-  # A LicenceRef cannot be used in this case, see:
-  # https://github.com/conda-forge/staged-recipes/pull/12882#discussion_r504086944
   license: LicenseRef-NVIDIA-End-User-License-Agreement
   license_file: NVIDIA_EULA
   license_url: https://docs.nvidia.com/cuda/eula/index.html


### PR DESCRIPTION
The comment is outdated since https://github.com/conda-forge/cudatoolkit-feedstock/commit/02c236d129d4f6297fca77506b60229b32c94612 change the license to use LicenseRef-

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
